### PR TITLE
[TBDGen][Test] Add expected failure for symbol difference on iOS

### DIFF
--- a/test/TBD/multimodule-implied-objc.swift
+++ b/test/TBD/multimodule-implied-objc.swift
@@ -1,4 +1,5 @@
 // REQUIRES: VENDOR=apple
+// XFAIL: OS=ios
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/cache)
 // RUN: split-file %s %t


### PR DESCRIPTION
It turns out that on iOS builds theres variance on whether `OBJC_(META)CLASS` symbols get emitted & exported. What's important for TBDGen is that it matches what gets exposed in binaries and that is still upheld on iOS. 

resolves: rdar://123811306